### PR TITLE
Create greetings.yml

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,32 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:´welcome´
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1 
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Message that will be displayed on users'' first issue'
+        pr-message: 'Message that will be displayed on users'' first pr'
+- name: Close Stale Issues
+  uses: actions/stale@1.0.0
+  with:
+    # Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}
+    repo-token: 
+    # The message to post on the issue when tagging it. If none provided, will not mark iusses stale.
+    stale-issue-message: # optional
+    # The message to post on the pr when tagging it. If none provided, will not mark prs stale.
+    stale-pr-message: # optional
+    # The number of days old an issue can be before marking it stale
+    days-before-stale: # optional, default is 60
+    # The number of days to wait to close an issue or pr after it being marked stale
+    days-before-close: # optional, default is 7
+    # The label to apply when an issue is stale
+    stale-issue-label: # optional, default is Stale
+    # The label to apply when a pr is stale
+    stale-pr-label: # optional, default is Stale
+    # The maximum number of operations per run, used to control rate limiting
+    operations-per-run: # optional, default is 30


### PR DESCRIPTION
- name: Close Stale Issues
  uses: actions/stale@1.0.0
  with:
    # Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}
    repo-token: 
    # The message to post on the issue when tagging it. If none provided, will not mark iusses stale.
    stale-issue-message: # optional
    # The message to post on the pr when tagging it. If none provided, will not mark prs stale.
    stale-pr-message: # optional
    # The number of days old an issue can be before marking it stale
    days-before-stale: # optional, default is 60
    # The number of days to wait to close an issue or pr after it being marked stale
    days-before-close: # optional, default is 7
    # The label to apply when an issue is stale
    stale-issue-label: # optional, default is Stale
    # The label to apply when a pr is stale
    stale-pr-label: # optional, default is Stale
    # The maximum number of operations per run, used to control rate limiting
    operations-per-run: # optional, default is 30